### PR TITLE
Update coupling.py

### DIFF
--- a/coupling.py
+++ b/coupling.py
@@ -40,9 +40,9 @@ def coupling(data,window):
 
 
     #temporal smoothing
-    temp = np.reshape(mtd,[der,nodes*nodes])
-    sma = pd.rolling_mean(temp,window)
-    sma = np.reshape(sma,[der,nodes,nodes])
+    temp = pd.DataFrame(np.reshape(mtd,[der,nodes*nodes]))
+    sma = temp.rolling(window).mean()
+    sma = np.reshape(sma.as_matrix(),[der,nodes,nodes])
     
     return (mtd, sma)
     


### PR DESCRIPTION
Hi, thanks for sharing this script. I've proposed a change as pd.rolling_mean() has been deprecated (pandas 0.18.0 onwards). BW, George.