### PR TITLE
Adding Dockerfile and CircleCI orbs for reproducible builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+
+orbs:
+  # https://circleci.com/orbs/registry/orb/circleci/docker-publish
+  docker-publish: circleci/docker-publish@0.1.3
+workflows:
+
+  # This workflow will be run on all branches but master (to test)
+  # Since there is no python module, versions coincide with Github commit SHAs
+  build_without_publishing_job:
+    jobs:
+      - docker-publish/publish:
+          image: poldracklab/coupling
+          deploy: false
+          filters:
+            branches:
+              ignore: 
+                - master
+
+  # This workflow will deploy images on merge to master only
+  docker_with_lifecycle:
+    jobs:
+      # Deploy a container tagged with latest
+      - docker-publish/publish:
+          image: poldracklab/coupling
+          tag: latest
+          filters:
+            branches:
+             only: master
+      # Deploy a container tagged with Github commit
+      - docker-publish/publish:
+          image: poldracklab/coupling
+          filters:
+            branches:
+             only: master
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM continuumio/miniconda3
+
+# docker build -t poldracklab/coupling .
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y git wget && \
+    mkdir -p /code && \
+    conda update -n base -c defaults conda && \
+    conda install -y pandas==0.18.0 numpy
+
+
+ADD . /code
+WORKDIR /code
+RUN chmod u+x /code/coupling.py
+ENTRYPOINT ["python"]
+CMD ["/code/coupling.py"]


### PR DESCRIPTION
This pull request will do the following:

 - a Dockerfile to build a container to run the coupling.py as (likely) it was originally done.
 - addition of continuous integration on CircleCI to build the Dockerfile. This container deploys to [poldracklab/coupling](https://cloud.docker.com/u/poldracklab/repository/docker/poldracklab/coupling) which seems appropriate as @macshine did the work while working with Poldracklab.

I've run the first build from the researchapps organization, the idea being that Mac might not have time to set up the build / accounts to do the push from here (and he always could if desired). If this is desired, you can simply log into CircleCI and enable the repository. I would suggest building on forked pull requests and cancelling redundant builds. You will also need to add `DOCKER_LOGIN` and `DOCKER_PASSWORD` as encrypted environment variables.

We will need to test the container (someone that has data will need to do this). @george-gifford since you are testing the script, would you care to try the container? The entrypoint to the container is coupling.py, but to get an interactive python terminal you can do:

```bash
docker run -v $PWD:/data -it --entrypoint python poldracklab/coupling 
...
> from coupling import *
```
In the above, the working directory is /code that has coupling.py, and we've mounted your $PWD to /data so you can add data files to use there.